### PR TITLE
MetadataのURLを修正

### DIFF
--- a/src/components/MetadataForm.tsx
+++ b/src/components/MetadataForm.tsx
@@ -56,8 +56,11 @@ function MetadataForm(): JSX.Element {
           console.log(e);
           setError(e);
         });
-      const url = new URL(metadata.url);
-      setResponse(`https://dweb.link/ipfs/${url.hostname}${url.pathname}`);
+
+      if (metadata) {
+        const CIDWithPath = metadata.url.replace('ipfs://', '');
+        setResponse(`https://dweb.link/ipfs/${CIDWithPath}`);
+      }
     }
     setIsLoading(false);
   });


### PR DESCRIPTION
## Changes

- MetadataのURLを正規化
  - before: https://dweb.link/ipfs///bafyreiedm7rarzgnlf6nu37jxq5wyc67v6jkfr3r46a7wvhxyio27s22wu/metadata.json
  - after: https://dweb.link/ipfs/bafyreiedm7rarzgnlf6nu37jxq5wyc67v6jkfr3r46a7wvhxyio27s22wu/metadata.json

## Instructions for reviewer

```sh
cp .env.example .env
vi .env # Set VITE_NFT_STORAGE_API_KEY variable to publish metadata
yarn start
# Open your browser, upload metadata and check the displayed url
```